### PR TITLE
Handle punctuation

### DIFF
--- a/lib/recase/cases/snake_case.ex
+++ b/lib/recase/cases/snake_case.ex
@@ -16,10 +16,15 @@ defmodule Recase.SnakeCase do
   def convert(""), do: ""
   def convert(value) do
     value
-    |> String.trim
-    |> replace(~r/[\s\.\-]/, @sep)
-    |> replace(~r/([a-z\d])([A-Z])/, "\\1#{@sep}\\2")
-    |> replace(~r/([A-Z]+)([A-Z][a-z\d]+)/, "\\1#{@sep}\\2")
+    |> String.split(~r/[^a-zA-Z0-9]+/)
+    |> Enum.map(fn(word) ->
+      word
+      |> replace(~r/[\s\.\-]/, @sep)
+      |> replace(~r/([a-z\d])([A-Z])/, "\\1#{@sep}\\2")
+      |> replace(~r/([A-Z]+)([A-Z][a-z\d]+)/, "\\1#{@sep}\\2")
+      end)
+    |> Enum.join(@sep)
     |> String.downcase
+    |> String.trim(@sep)
   end
 end

--- a/test/recase_test/constant_case_test.exs
+++ b/test/recase_test/constant_case_test.exs
@@ -13,10 +13,9 @@ defmodule Recase.ConstantCaseTest do
     assert convert("constant_Case") == expected
     assert convert("constant.Case") == expected
     assert convert("ConstantCase") == expected
-  end
-
-  test "should not modify extra chars" do
-    assert convert("!#$%^&*(){}[]~`'\"") == "!#$%^&*(){}[]~`'\""
+    assert convert("--constant-case--") == expected
+    assert convert("constant#case") == expected
+    assert convert("constant?!case") == expected
   end
 
   test "should return single letter" do

--- a/test/recase_test/dot_case_test.exs
+++ b/test/recase_test/dot_case_test.exs
@@ -13,10 +13,9 @@ defmodule Recase.DotCaseTest do
     assert convert("dotCase") == expected
     assert convert("dot.Case") == expected
     assert convert("dot-case") == expected
-  end
-
-  test "should not modify extra chars" do
-    assert convert("!#$%^&*(){}[]~`'\"") == "!#$%^&*(){}[]~`'\""
+    assert convert("--dot-case--") == expected
+    assert convert("dot#case") == expected
+    assert convert("dot?!case") == expected
   end
 
   test "should return single letter" do

--- a/test/recase_test/kebab_case_test.exs
+++ b/test/recase_test/kebab_case_test.exs
@@ -12,10 +12,9 @@ defmodule Recase.KebabCaseTest do
     assert convert("KebabCase") == "kebab-case"
     assert convert("Kebab.Case") == "kebab-case"
     assert convert("kebab-case") == "kebab-case"
-  end
-
-  test "should not modify extra chars" do
-    assert convert("!#$%^&*(){}[]~`'\"") == "!#$%^&*(){}[]~`'\""
+    assert convert("--kebab-case--") == "kebab-case"
+    assert convert("kebab#case") == "kebab-case"
+    assert convert("kebab?!case") == "kebab-case"
   end
 
   test "should return single letter" do

--- a/test/recase_test/snake_case_test.exs
+++ b/test/recase_test/snake_case_test.exs
@@ -13,10 +13,9 @@ defmodule Recase.SnakeCaseTest do
     assert convert("SnakeCase") == "snake_case"
     assert convert("Snake.Case") == "snake_case"
     assert convert("SNAKE_CASE") == "snake_case"
-  end
-
-  test "should not modify extra chars" do
-    assert convert("!#$%^&*(){}[]~`'\"") == "!#$%^&*(){}[]~`'\""
+    assert convert("--snake-case--") == "snake_case"
+    assert convert("snake#case") == "snake_case"
+    assert convert("snake?!case") == "snake_case"
   end
 
   test "should return single letter" do


### PR DESCRIPTION
Following up on #5 with something to take a look at. If the approach is acceptable perhaps it would be better to move to snake_case.ex instead since it seems like the other cases depend on that one (and update the other tests).

I tried running `mix credo --strict` and `mix dialyzer` but they errorred on the main sobolevn/recase master branch as well so I don't think this PR introduces any new cod equality issues. If you're not seeing the same I can provide more details on what I'm seeing.

Last thing (and perhaps this should be separate) but using Lodash's implementation as a guide, they also split up strings with digits ex you can try `_.snakeCase("ab-cD-e0-Df-GH-I1-2j-3K-45") === "ab_c_d_e_0_df_gh_i_1_2_j_3_k_45"` in the developer console in lodash.com.