### PR TITLE
Resolves warning about quoted keyword "coveralls"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Recase.Mixfile do
       # Test coverage:
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: [
-       "coveralls": :test,
+       coveralls: :test,
        "coveralls.detail": :test,
        "coveralls.post": :test,
        "coveralls.html": :test,


### PR DESCRIPTION
I see this one in my project whenever my recase dependency is compiled.  The warning was added in Elixir 1.7.   

Here's a small fix that removes the unneeded quotes on "coveralls" in mix.exs to resolve it.