### PR TITLE
#57: Explicitly test for phrases with more than 2 words

### DIFF
--- a/test/recase_test/camel_case_test.exs
+++ b/test/recase_test/camel_case_test.exs
@@ -24,6 +24,11 @@ defmodule Recase.CamelCaseTest do
     assert convert("a") == "a"
   end
 
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "threeSeparateWords"
+    assert convert("MoreThanThreeWords") == "moreThanThreeWords"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end

--- a/test/recase_test/constant_case_test.exs
+++ b/test/recase_test/constant_case_test.exs
@@ -8,6 +8,7 @@ defmodule Recase.ConstantCaseTest do
   test "should constant case usual text" do
     expected = "CONSTANT_CASE"
     assert convert("constant case") == expected
+    assert convert("constant case") == expected
     assert convert("constantCase") == expected
     assert convert("constant-Case") == expected
     assert convert("constant_Case") == expected
@@ -20,6 +21,11 @@ defmodule Recase.ConstantCaseTest do
 
   test "should return single letter" do
     assert convert("a") == "A"
+  end
+
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "THREE_SEPARATE_WORDS"
+    assert convert("MoreThanThreeWords") == "MORE_THAN_THREE_WORDS"
   end
 
   test "should return empty string" do

--- a/test/recase_test/dot_case_test.exs
+++ b/test/recase_test/dot_case_test.exs
@@ -22,6 +22,11 @@ defmodule Recase.DotCaseTest do
     assert convert("a") == "a"
   end
 
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "three.separate.words"
+    assert convert("MoreThanThreeWords") == "more.than.three.words"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end

--- a/test/recase_test/kebab_case_test.exs
+++ b/test/recase_test/kebab_case_test.exs
@@ -21,6 +21,11 @@ defmodule Recase.KebabCaseTest do
     assert convert("a") == "a"
   end
 
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "three-separate-words"
+    assert convert("MoreThanThreeWords") == "more-than-three-words"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end

--- a/test/recase_test/pascal_case_test.exs
+++ b/test/recase_test/pascal_case_test.exs
@@ -22,6 +22,11 @@ defmodule Recase.PascalCaseTest do
     assert convert("a") == "A"
   end
 
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "ThreeSeparateWords"
+    assert convert("MoreThanThreeWords") == "MoreThanThreeWords"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end

--- a/test/recase_test/path_case_test.exs
+++ b/test/recase_test/path_case_test.exs
@@ -31,6 +31,11 @@ defmodule Recase.PathCaseTest do
     assert convert("a") == "a"
   end
 
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "Three/Separate/Words"
+    assert convert("MoreThanThreeWords") == "More/Than/Three/Words"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end

--- a/test/recase_test/sentence_case_test.exs
+++ b/test/recase_test/sentence_case_test.exs
@@ -17,6 +17,15 @@ defmodule Recase.SentenceCaseTest do
     assert convert("sentence?!case") == "Sentence case"
   end
 
+  test "should return single letter" do
+    assert convert("a") == "A"
+  end
+
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "Three separate words"
+    assert convert("MoreThanThreeWords") == "More than three words"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end

--- a/test/recase_test/snake_case_test.exs
+++ b/test/recase_test/snake_case_test.exs
@@ -22,6 +22,11 @@ defmodule Recase.SnakeCaseTest do
     assert convert("a") == "a"
   end
 
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "three_separate_words"
+    assert convert("MoreThanThreeWords") == "more_than_three_words"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end

--- a/test/recase_test/title_case_test.exs
+++ b/test/recase_test/title_case_test.exs
@@ -17,6 +17,15 @@ defmodule Recase.TitleCaseTest do
     assert convert("title?!case") == "Title Case"
   end
 
+  test "should return single letter" do
+    assert convert("a") == "A"
+  end
+
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "Three Separate Words"
+    assert convert("MoreThanThreeWords") == "More Than Three Words"
+  end
+
   test "should return empty string" do
     assert convert("") == ""
   end


### PR DESCRIPTION
See https://github.com/sobolevn/recase/issues/57, previous versions (up through 0.4.0) behave as follows: 

```
Recase.to_camel("fooBar")
> "fooBar" # Correct

Recase.to_camel("fooBarBaz")
> "foobarBaz" # Incorrect, this should be "fooBarBaz"

Recase.to_camel("fooBarBazBiz")
> "foobarbazBiz" # Incorrect, this should be "fooBarBazBiz"
```

This has been fixed in master already, this PR is just to add test cases to explicitly prevent regressions.