### PR TITLE
Add Header-Case

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Recase.to_title("some-value") # => "Some Value"
 Recase.to_title("some value") # => "Some Value"
 ```
 
+### Header
+
+Header case uses the same case as PascalCase, while using `-` as a separator.
+
+```elixir
+Recase.to_header("SomeValue") # => "Some-Value"
+Recase.to_header("some value") # => "Some-Value"
+```
+
 ### Enumerable
 
 You can convert all keys in an enumerable with:

--- a/lib/recase.ex
+++ b/lib/recase.ex
@@ -9,6 +9,7 @@ defmodule Recase do
     CamelCase,
     ConstantCase,
     DotCase,
+    HeaderCase,
     KebabCase,
     PascalCase,
     PathCase,
@@ -145,4 +146,18 @@ defmodule Recase do
   """
   @spec to_title(String.t()) :: String.t()
   def to_title(value), do: TitleCase.convert(value)
+
+  @doc """
+  Converts string to Header-Case
+
+  ## Examples
+
+  iex> Recase.to_header("SomeValue")
+  "Some-Value"
+
+  iex> Recase.to_header("some value")
+  "Some-Value"
+  """
+  @spec to_header(String.t()) :: String.t()
+  def to_header(value), do: HeaderCase.convert(value)
 end

--- a/lib/recase/cases/header_case.ex
+++ b/lib/recase/cases/header_case.ex
@@ -1,0 +1,24 @@
+defmodule Recase.HeaderCase do
+  @moduledoc """
+  Module to convert strings to `Header-Case`.
+
+  This module should not be used directly.
+
+  ## Examples
+
+      iex> Recase.to_header "foo_barBaz-λambdaΛambda-привет-Мир"
+      "Foo-Bar-Baz-Λambda-Λambda-Привет-Мир"
+
+  Header case is the case suggested in [section 3.4.7 of RFC 822]
+  (https://tools.ietf.org/html/rfc822#section-3.4.7) to be used
+  in the message-creation process.
+  """
+
+  import Recase.Generic, only: [rejoin: 2]
+
+  @sep "-"
+
+  @spec convert(String.t()) :: String.t()
+  def convert(value) when is_binary(value),
+    do: rejoin(value, separator: @sep, case: :title)
+end

--- a/test/recase_test/header_case_test.exs
+++ b/test/recase_test/header_case_test.exs
@@ -1,0 +1,33 @@
+defmodule Recase.HeaderCaseTest do
+  use ExUnit.Case
+
+  import Recase.HeaderCase
+
+  doctest Recase.HeaderCase
+
+  test "should header case usual text" do
+    assert convert("header case") == "Header-Case"
+    assert convert("headerCase") == "Header-Case"
+    assert convert("Header_Case") == "Header-Case"
+    assert convert("HeaderCase") == "Header-Case"
+    assert convert("Header.Case") == "Header-Case"
+    assert convert("Header-Case") == "Header-Case"
+    assert convert("header-case") == "Header-Case"
+    assert convert("--header-case--") == "Header-Case"
+    assert convert("header#case") == "Header-Case"
+    assert convert("header?!case") == "Header-Case"
+  end
+
+  test "should return single letter" do
+    assert convert("a") == "A"
+  end
+
+  test "should return phrases with more than 2 words" do
+    assert convert("ThreeSeparateWords") == "Three-Separate-Words"
+    assert convert("MoreThanThreeWords") == "More-Than-Three-Words"
+  end
+
+  test "should return empty string" do
+    assert convert("") == ""
+  end
+end


### PR DESCRIPTION
Converts the text to the standard header key representation as suggested
in RFC 822