### PR TITLE
Bugfix: do not attempt to enumerate over DateTimes when converting values

### DIFF
--- a/lib/recase/utils/enumerable.ex
+++ b/lib/recase/utils/enumerable.ex
@@ -41,6 +41,8 @@ defmodule Recase.Enumerable do
     |> Enum.map(fn value -> handle_value(value, fun, &convert_keys/2) end)
   end
 
+  defp handle_value(%DateTime{} = value, _fun, _converter), do: value
+
   defp handle_value(value, fun, converter)
        when is_map(value) or is_list(value) do
     converter.(value, fun)

--- a/test/utils_test/enumerable_test.exs
+++ b/test/utils_test/enumerable_test.exs
@@ -36,6 +36,26 @@ defmodule RecaseEnumerableTest do
                &Recase.to_pascal/1
              ) == ["upper case", "upper-case2"]
     end
+
+    test "should convert when value is a datetime" do
+      datetime = %DateTime{
+        year: 2000,
+        month: 2,
+        day: 29,
+        zone_abbr: "AMT",
+        hour: 23,
+        minute: 0,
+        second: 7,
+        utc_offset: -14_400,
+        std_offset: 0,
+        time_zone: "America/Manaus"
+      }
+
+      assert Recase.Enumerable.convert_keys(
+               %{"upper case" => datetime},
+               &Recase.to_pascal/1
+             ) == %{"UpperCase" => datetime}
+    end
   end
 
   describe "atomize_keys/2" do


### PR DESCRIPTION
Previously, `handle_value` checked if the value was a map: `is_map(value)` and, when true, enumerated over the value to convert the keys accordingly. However:

```elixir
{:ok, datetime} = DateTime.new("Etc/UTC")
is_map(datetime) # => true
```

resulting in the following error: `(Protocol.UndefinedError) protocol Enumerable not implemented for <DATETIME>`. This PR fixes that by just returning the value if it is a datetime.