### PR TITLE
Update handle_value to only convert values when the value has implemented the Enumerable protocol

### DIFF
--- a/lib/recase/utils/enumerable.ex
+++ b/lib/recase/utils/enumerable.ex
@@ -41,14 +41,15 @@ defmodule Recase.Enumerable do
     |> Enum.map(fn value -> handle_value(value, fun, &convert_keys/2) end)
   end
 
-  defp handle_value(%DateTime{} = value, _fun, _converter), do: value
+  defp handle_value(value, fun, converter) do
+    case Enumerable.impl_for(value) do
+      nil ->
+        value
 
-  defp handle_value(value, fun, converter)
-       when is_map(value) or is_list(value) do
-    converter.(value, fun)
+      _ ->
+        converter.(value, fun)
+    end
   end
-
-  defp handle_value(value, _, _), do: value
 
   defp cast_string(value) when is_binary(value), do: value
 


### PR DESCRIPTION
Earlier, I opened https://github.com/sobolevn/recase/pull/97/files because passing a DateTime value to the converter would fail, since it passed the `is_map` check, but would not work when passed to `Enum`; I fixed it by hardcoding a new pattern-matched function against DateTimes, and early returning the datetime. However, I now need the same functionality, but for [Decimal](https://hexdocs.pm/decimal/Decimal.html#to_float/1), which does not exist (and doesn't need to) in this lib. Unfortunately, `is_map(%Decimal{})` also returns true, and then fails when passed to `Enum`.

I think the best solution is to check if the Enumerable protocol is implemented, which may determine if the value can be passed to the next check.